### PR TITLE
Support for <pre> tag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "cheerio": "^0.20.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.8.0",
     "babel-eslint": "^5.0.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-es2015-loose": "^7.0.0",

--- a/src/processElement.js
+++ b/src/processElement.js
@@ -75,6 +75,9 @@
         if (['figure', 'div', 'figcaption'].indexOf(el.name) > -1) {
           return `\n${processed}`;
         }
+        if (el.name === 'pre') {
+            return `\n~~~\n${processed}\n~~~\n`;
+        }
         console.log(`parse-medium: unprocessed tag <${el.name}>`);
         return `\n${processed}`;
       }

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -71,6 +71,14 @@ test('processing of html tags', t => {
   expected = '\n![Cool](http://google.com/secondDoodle.jpg)';
   t.equal(actual, expected, 'should accept <figure> and get second img b/c first is low-res');
 
+  html = `<pre>function add (a, b) {
+      return a + b;
+  }</pre>`;
+  actual = processElement(html);
+  expected = `\n~~~\nfunction add (a, b) {
+      return a + b;
+  }\n~~~\n`;
+  t.equal(actual, expected, 'should accept <pre>');
 
   t.end();
 });
@@ -85,7 +93,7 @@ test('processing the html of an medium post', t => {
   actual = parsed.markdown;
   expected = fs.readFileSync(path.resolve(__dirname, '../../mocks/dan.md'), 'utf-8');
   t.equal(actual, expected, 'should parse local article successfuly');
-  
+
   actual = parsed.title;
   expected = 'Presentational and Container Components';
   t.equal(actual, expected, 'should parse for title');


### PR DESCRIPTION
The <pre> tag is used when the post have source code examples.

Also saved babel-cli in devDependencies, for the users that don't
have babel-cli globally.
